### PR TITLE
make issue labels look like github

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -9,6 +9,7 @@
 <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css' />
 <link rel="stylesheet" type="text/css" href="css/style.css" />
 <link rel="stylesheet" type="text/css" href="css/jquery.sidr.light.css" />
+<link rel="stylesheet" type="text/css" href="css/github_issues.css" />
 
 
 <title>Astropy | Contribute</title>
@@ -68,11 +69,11 @@
 	<section id="code">
 		<h2>Contribute code or documentation</h2>
 
-		<p>If you are interested in contributing fixes, code or documentation to Astropy (whether the core package or affiliated packages), you should join the <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a> mailing list/forum, and start looking at any related <a href="https://github.com/astropy/astropy/issues">issues</a>. In particular, we have introduced a labeling system used across most Astropy-related packages which will allow you to find good starting issues (the relevant label is "Package-novice" which means you don't need much prior experience of the package). You can use the following links to find all the issues labelled this way and also labeled by effort:</p>
+		<p>If you are interested in contributing fixes, code or documentation to Astropy (whether the core package or affiliated packages), you should join the <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a> mailing list/forum, and start looking at any related <a href="https://github.com/astropy/astropy/issues">issues</a>. In particular, we have introduced a labeling system used across most Astropy-related packages which will allow you to find good starting issues.  A good label to start with is <a href="https://github.com/search?p=2&q=label%3Apackage-novice&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-package">Package-novice</a> which means you don't need much prior experience of the package. You can use the following links to find all the issues labelled this way and also labeled by how much work they involve:</p>
     <ul>
-      <li><a href="https://github.com/search?p=2&q=label%3Apackage-novice+label%3Aeffort-low&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93">Effort-low</a>: issues that should take a few hours at most
-      <li><a href="https://github.com/search?p=2&q=label%3Apackage-novice+label%3Aeffort-medium&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93">Effort-medium</a>: issues that should take a few days at most
-      <li><a href="https://github.com/search?p=2&q=label%3Apackage-novice+label%3Aeffort-high&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93">Effort-high</a>: longer term issues
+      <li><a href="https://github.com/search?p=2&q=label%3Apackage-novice+label%3Aeffort-low&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-effort">Effort-low</a>: issues that should take a few hours at most
+      <li><a href="https://github.com/search?p=2&q=label%3Apackage-novice+label%3Aeffort-medium&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-effort">Effort-medium</a>: issues that should take a few days at most
+      <li><a href="https://github.com/search?p=2&q=label%3Apackage-novice+label%3Aeffort-high&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-effort">Effort-high</a>: longer term issues
       </ul>
       <p>You may also want to familiarize yourself with the <a href="http://docs.astropy.org/en/latest/#developer-documentation" target="_blank">developer documentation</a>, particularly the <a href="http://docs.astropy.org/en/latest/development/codeguide.html">coding</a> and <a href="http://docs.astropy.org/en/latest/development/docguide.html">documentation</a> guidelines.</p>
 

--- a/css/github_issues.css
+++ b/css/github_issues.css
@@ -1,0 +1,22 @@
+.github-label-effort {
+	font-size: 11px;
+	font-weight: bold;
+	padding: 3px 4px;
+	border-radius: 2px;
+	line-height: 1;
+	box-shadow: inset 0 -1px 0 rgba(0,0,0,0.12);
+	background-color: #fef2c0;
+	color: #333026;
+	font: Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
+}
+.github-label-package {
+	font-size: 11px;
+	font-weight: bold;
+	padding: 3px 4px;
+	border-radius: 2px;
+	line-height: 1;
+	box-shadow: inset 0 -1px 0 rgba(0,0,0,0.12);
+	background-color: #bfe5bf;
+	color: #333026;
+	font: Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
+}


### PR DESCRIPTION
an update to astropy/astropy.github.com#66 to make the labels look like github-style labels
